### PR TITLE
Update README.md for url sample to fix typo

### DIFF
--- a/url/README.md
+++ b/url/README.md
@@ -7,6 +7,6 @@ passed on the command line in a window.
 
 - Install [Node LTS](https://nodejs.org)
 - Clone this repository
-- `cd price`
+- `cd url`
 - `npm install` to install the application's dependencies
 - `npm start https://github.com` to start the application and load GitHub


### PR DESCRIPTION
It looks like the README instructions were copied from the `price` sample. Change `cd price` to `cd url` for the `url` sample project.