### PR TITLE
bump app height and center content vertically

### DIFF
--- a/prices/app.js
+++ b/prices/app.js
@@ -11,7 +11,7 @@ electron.app.once('ready', function () {
     // Set the initial width to 400px
     width: 400,
     // Set the initial height to 400px
-    height: 400,
+    height: 500,
     // Don't show the window until it ready, this prevents any white flickering
     show: false,
     // Don't allow the window to be resized.

--- a/prices/styles.css
+++ b/prices/styles.css
@@ -21,6 +21,12 @@ html, body, .container-fluid {
   height: 33.33333333%;
 }
 
+.row > div {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .price {
   padding-right: 5px;
 }


### PR DESCRIPTION
Fixes #2 

This PR bumps up the window height to make more room for content, and adds a CSS rule to vertically center the content in each row.

I tried to verify this fix on Windows 10, but run into an unrelated [XHR bug](https://github.com/electron/electron/issues/7221).

@cfjedimaster would you care to give this a try branch a try and let me know how it works for you?