### PR TITLE
ES6 migration broke "hash" example

### DIFF
--- a/hash/window.js
+++ b/hash/window.js
@@ -1,7 +1,7 @@
 $(() => {
   const crypto = require('crypto')
 
-  $('#text-input').bind('input propertychange', () => {
+  $('#text-input').bind('input propertychange', function() {
     const text = this.value
 
     const md5 = crypto.createHash('md5').update(text, 'utf8').digest('hex')


### PR DESCRIPTION
This pull request fixes #10 but I'm unsure if there's a more appropriate ES6 syntax to use.

/fyi @codebytere since this reverts a part of [your migration change](https://github.com/electron/simple-samples/commit/ff0b21c96b9bfd5393ec894d3cf7ce02c167b0c8#diff-ae2ff18d2b140fc08473162414a119c8) and suspect you may have a better fix in mind.