### PR TITLE
update electron version to v7

### DIFF
--- a/activity-monitor/app.js
+++ b/activity-monitor/app.js
@@ -17,7 +17,11 @@ app.once('ready', () => {
     // set the background color to black
     backgroundColor: "#111",
     // Don't show the window until it's ready, this prevents any white flickering
-    show: false
+    show: false,
+    // Set nodeIntegration true //default false
+    webPreferences:{
+      nodeIntegration:true
+    }
   })
 
   window.loadURL(url.format({

--- a/activity-monitor/package.json
+++ b/activity-monitor/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   }
 }

--- a/electron-tray/package.json
+++ b/electron-tray/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   }
 }

--- a/hash/app.js
+++ b/hash/app.js
@@ -16,7 +16,11 @@ app.once('ready', () => {
     // background color of the page, this prevents any white flickering
     backgroundColor: "#D6D8DC",
     // Don't show the window until it's ready, this prevents any white flickering
-    show: false
+    show: false,
+    // Set nodeIntegration true //default false
+    webPreferences:{
+      nodeIntegration:true
+    }
   })
 
   // Load a URL in the window to the local index.html path

--- a/hash/package.json
+++ b/hash/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   }
 }

--- a/mirror/app.js
+++ b/mirror/app.js
@@ -13,7 +13,11 @@ app.once('ready', () => {
     // Make the window transparent
     transparent: true,
     // Remove the frame from the window
-    frame: false
+    frame: false,
+    // Set nodeIntegration true //default false
+    webPreferences:{
+      nodeIntegration:true
+    }
   })
 
   // Load a URL in the window to the local index.html path

--- a/mirror/package.json
+++ b/mirror/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   }
 }

--- a/mirror/window.js
+++ b/mirror/window.js
@@ -1,8 +1,11 @@
 // Run this function after the page has loaded
 $(() => {
-  const electron = require('electron')
+  const {remote} = require('electron')
+  
+  // get screen through remote module
+  const {screen}=remote
 
-  const display = electron.screen.getPrimaryDisplay() // http://electron.atom.io/docs/api/screen
+  const display = screen.getPrimaryDisplay() // http://electron.atom.io/docs/api/screen
 
   const constraints = {
     video: {

--- a/prices/app.js
+++ b/prices/app.js
@@ -15,7 +15,11 @@ app.once('ready', () => {
     // Don't show the window until it ready, this prevents any white flickering
     show: false,
     // Don't allow the window to be resized.
-    resizable: false
+    resizable: false,
+    // Set nodeIntegration true //default false
+    webPreferences:{
+      nodeIntegration:true
+    }
   })
 
   // Load a URL in the window to the local index.html path

--- a/prices/package.json
+++ b/prices/package.json
@@ -9,7 +9,7 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   },
   "dependencies": {
     "papaparse": "^4.6.0"

--- a/url/package.json
+++ b/url/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "electron": "^3.0.2"
+    "electron": "^7.1.7"
   }
 }


### PR DESCRIPTION
update electron version to v7 and fix some configuration and interface to fit it.
- In the latest version of electron, nodeIntegration is default false, hence setting nodeIntegration true to fit. Otherwise, `require` is prompted to be undefined. 
- In the renderer process, remote module is needed to access to screen module. Hence fix that in mirror demo.  